### PR TITLE
Add manual implementations for Clone on types using PhantomData

### DIFF
--- a/src/apex/blackboard.rs
+++ b/src/apex/blackboard.rs
@@ -123,11 +123,21 @@ pub mod abstraction {
     use crate::prelude::*;
 
     /// Blackboard abstraction struct
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct Blackboard<B: ApexBlackboardP1> {
         _b: PhantomData<AtomicPtr<B>>,
         id: BlackboardId,
         max_size: MessageSize,
+    }
+
+    impl<B: ApexBlackboardP1> Clone for Blackboard<B> {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+                max_size: self.max_size,
+            }
+        }
     }
 
     /// Free extra functions for implementer of [ApexBlackboardP1]

--- a/src/apex/buffer.rs
+++ b/src/apex/buffer.rs
@@ -109,12 +109,23 @@ pub mod abstraction {
     use crate::prelude::*;
 
     /// Buffer abstraction struct
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct Buffer<B: ApexBufferP1> {
         _b: PhantomData<AtomicPtr<B>>,
         id: BufferId,
         max_size: MessageSize,
         max_number_msgs: MessageRange,
+    }
+
+    impl<B: ApexBufferP1> Clone for Buffer<B> {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+                max_size: self.max_size,
+                max_number_msgs: self.max_number_msgs,
+            }
+        }
     }
 
     /// Free extra functions for implementer of [ApexBufferP1]

--- a/src/apex/event.rs
+++ b/src/apex/event.rs
@@ -101,10 +101,19 @@ pub mod abstraction {
     use crate::prelude::*;
 
     /// Event abstraction struct
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct Event<E: ApexEventP1> {
         _b: PhantomData<AtomicPtr<E>>,
         id: EventId,
+    }
+
+    impl<E: ApexEventP1> Clone for Event<E> {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+            }
+        }
     }
 
     /// Free extra functions for implementer of [ApexEventP1]

--- a/src/apex/mutex.rs
+++ b/src/apex/mutex.rs
@@ -128,11 +128,21 @@ pub mod abstraction {
         }
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct Mutex<M: ApexMutexP1> {
         _b: PhantomData<AtomicPtr<M>>,
         id: MutexId,
         priority: Priority,
+    }
+
+    impl<M: ApexMutexP1> Clone for Mutex<M> {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+                priority: self.priority,
+            }
+        }
     }
 
     pub trait ApexMutexP1Ext: ApexMutexP1 + Sized {

--- a/src/apex/process.rs
+++ b/src/apex/process.rs
@@ -235,10 +235,19 @@ pub mod abstraction {
         }
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct Process<P: ApexProcessP4> {
         _p: PhantomData<AtomicPtr<P>>,
         id: ProcessId,
+    }
+
+    impl<P: ApexProcessP4> Clone for Process<P> {
+        fn clone(&self) -> Self {
+            Self {
+                _p: self._p,
+                id: self.id,
+            }
+        }
     }
 
     pub trait ApexProcessP1Ext: ApexProcessP1 + Sized {

--- a/src/apex/queuing.rs
+++ b/src/apex/queuing.rs
@@ -80,7 +80,7 @@ pub mod abstraction {
     use crate::hidden::Key;
     use crate::prelude::*;
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct QueuingPortSender<
         const MSG_SIZE: MessageSize,
         const NB_MSGS: MessageRange,
@@ -90,7 +90,18 @@ pub mod abstraction {
         id: QueuingPortId,
     }
 
-    #[derive(Debug, Clone)]
+    impl<const MSG_SIZE: MessageSize, const NB_MSGS: MessageRange, S: ApexQueuingPortP4> Clone
+        for QueuingPortSender<MSG_SIZE, NB_MSGS, S>
+    {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+            }
+        }
+    }
+
+    #[derive(Debug)]
     pub struct QueuingPortReceiver<
         const MSG_SIZE: MessageSize,
         const NB_MSGS: MessageRange,
@@ -98,6 +109,17 @@ pub mod abstraction {
     > {
         _b: PhantomData<AtomicPtr<Q>>,
         id: QueuingPortId,
+    }
+
+    impl<const MSG_SIZE: MessageSize, const NB_MSGS: MessageRange, S: ApexQueuingPortP4> Clone
+        for QueuingPortReceiver<MSG_SIZE, NB_MSGS, S>
+    {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+            }
+        }
     }
 
     pub trait ApexQueuingPortP4Ext: ApexQueuingPortP4 + Sized {

--- a/src/apex/sampling.rs
+++ b/src/apex/sampling.rs
@@ -101,17 +101,38 @@ pub mod abstraction {
         }
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct SamplingPortSource<const MSG_SIZE: MessageSize, S: ApexSamplingPortP4> {
         _b: PhantomData<AtomicPtr<S>>,
         id: SamplingPortId,
     }
 
-    #[derive(Debug, Clone)]
+    impl<const MSG_SIZE: MessageSize, S: ApexSamplingPortP4> Clone for SamplingPortSource<MSG_SIZE, S> {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+            }
+        }
+    }
+
+    #[derive(Debug)]
     pub struct SamplingPortDestination<const MSG_SIZE: MessageSize, S: ApexSamplingPortP4> {
         _b: PhantomData<AtomicPtr<S>>,
         id: SamplingPortId,
         refresh: Duration,
+    }
+
+    impl<const MSG_SIZE: MessageSize, S: ApexSamplingPortP4> Clone
+        for SamplingPortDestination<MSG_SIZE, S>
+    {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+                refresh: self.refresh,
+            }
+        }
     }
 
     pub trait ApexSamplingPortP4Ext: ApexSamplingPortP4 + Sized {

--- a/src/apex/semaphore.rs
+++ b/src/apex/semaphore.rs
@@ -96,11 +96,21 @@ pub mod abstraction {
     use crate::hidden::Key;
     use crate::prelude::*;
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct Semaphore<S: ApexSemaphoreP1> {
         _b: PhantomData<AtomicPtr<S>>,
         id: SemaphoreId,
         maximum: SemaphoreValue,
+    }
+
+    impl<S: ApexSemaphoreP1> Clone for Semaphore<S> {
+        fn clone(&self) -> Self {
+            Self {
+                _b: self._b,
+                id: self.id,
+                maximum: self.maximum,
+            }
+        }
     }
 
     pub trait ApexSemaphoreP1Ext: ApexSemaphoreP1 + Sized {


### PR DESCRIPTION
The auto-derived impl adds all type parameters to the trait bounds, even though `PhantomData` implements `Clone for `?Sized`.